### PR TITLE
Allow travis failures on PHP nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
 - 7.0
 - 7.1
 - nightly
+matrix:
+  allow_failures:
+    - php: nightly
 before_script: composer install
 services:
   - redis-server


### PR DESCRIPTION
This setting allows you to get a green pass on travis when there are failures only with php nightly.